### PR TITLE
Add --depth=1 to git clone command

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -21,7 +21,7 @@ const nodeRepo = 'https://github.com/nodejs/node';
 
 async function gitClone () {
   log.info('Cloning Node.js repository from GitHub...');
-  const args = [ 'clone', '--bare', '--progress', nodeRepo, 'node/.git' ];
+  const args = [ 'clone', '--bare', '--progress', '--depth=1', nodeRepo, 'node/.git' ];
   const promise = spawn('git', args, { cwd: buildPath });
   progress(promise, thresholds('clone'));
   await promise;


### PR DESCRIPTION
This will decrease `git clone` acquisition times a bit when building from source.