### PR TITLE
Update request/request to fix CVE-2018-1000620

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "in-publish": "2.0.0",
     "minimist": "1.2.0",
     "progress": "2.0.0",
-    "request": "2.85.0",
+    "request": "2.88.0",
     "request-progress": "3.0.0",
     "semver": "5.5.0",
     "unique-temp-dir": "1.0.0"


### PR DESCRIPTION
Updated https://github.com/request/request dependency to fix https://nvd.nist.gov/vuln/detail/CVE-2018-1000620.

Unable to run tests locally as you require Mac OS X 64-bit.