### PR TITLE
Update dependencies and remove fixed versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,28 +23,28 @@
     ]
   },
   "dependencies": {
-    "babel-runtime": "6.26.0",
-    "byline": "5.0.0",
-    "chalk": "2.4.1",
-    "expand-template": "1.1.1",
-    "fs-extra": "6.0.1",
-    "in-publish": "2.0.0",
-    "minimist": "1.2.0",
-    "progress": "2.0.0",
-    "request": "2.85.0",
-    "request-progress": "3.0.0",
-    "semver": "5.5.0",
-    "unique-temp-dir": "1.0.0"
+    "babel-runtime": "~6.26.0",
+    "byline": "~5.0.0",
+    "chalk": "~2.4.1",
+    "expand-template": "~1.1.1",
+    "fs-extra": "~6.0.1",
+    "in-publish": "~2.0.0",
+    "minimist": "~1.2.0",
+    "progress": "~2.0.0",
+    "request": "~2.88.0",
+    "request-progress": "~3.0.0",
+    "semver": "~5.6.0",
+    "unique-temp-dir": "~1.0.0"
   },
   "devDependencies": {
-    "ava": "0.25.0",
-    "babel-cli": "6.26.0",
-    "babel-eslint": "8.2.3",
-    "babel-plugin-transform-async-to-generator": "6.24.1",
-    "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-es2015": "6.24.1",
-    "babel-register": "6.26.0",
-    "eslint-config-klopov": "0.13.0"
+    "ava": "~0.25.0",
+    "babel-cli": "~6.26.0",
+    "babel-eslint": "~8.2.3",
+    "babel-plugin-transform-async-to-generator": "~6.24.1",
+    "babel-plugin-transform-runtime": "~6.23.0",
+    "babel-preset-es2015": "~6.24.1",
+    "babel-register": "~6.26.0",
+    "eslint-config-klopov": "~0.13.0"
   },
   "scripts": {
     "babel": "node test/rimraf-es5.js && babel lib --out-dir lib-es5",


### PR DESCRIPTION
This patch updates some deps with non-major version changes, and also
relaxes the versioning used in the package.json to allow bugfix
releases.

Using pinned versions is probably a well intentioned but naive
restriction that prevents a consumer from automatically receiving
security fixes unless the package author approves them, which can take a
long time. Pinned dependencies don't work in Node-land anyway, as NPM
will happily give you multiple copies of a specific library at different
versions, and pins do also not prevent transitive dependencies from
including version ranges anyway. For these reasons, it is more a
security risk than a reliability insurance.